### PR TITLE
Display all user's sleep quality average on app

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -244,8 +244,12 @@
         <section class='friends-card hide' id='sleep-friends-card'>
           <button type='button' aria-label="return from sleep friends" id="sleep-return" name='button' class='go-back-button'></button>
           <div class='card-data-line'>
-            <p>LAST NIGHT'S LONGEST SLEEPER</p>
+            <p>LAST NIGHT'S LONGEST SLEEPER(S)</p>
             <h4 id='sleep-friend-longest-sleeper'></h4>
+          </div>
+          <div class='card-data-line'>
+            <p>ALL USER'S AVERAGE SLEEP QUALITY</p>
+            <h4 id='sleep-friend-quality-average'></h4>
           </div>
         </section>
         <section class='calendar-card hide' id='sleep-calendar-card'>

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -55,7 +55,6 @@ const userList = userData.map(user => {
 const userRepository = new UserRepository(userList);
 let user = userRepository.users[0];
 user.findWeeklyFriendActivityData(activityData, todayDate);
-user.findFriendsNames(userRepository.users);
 user.calcFriendsWeeklyStepAvg()
 
 
@@ -68,7 +67,8 @@ sleep.calcWeeklyAvgData(todayDate);
 
 //userRepo
 userRepository.calcDailyUserData(todayDate, activityData, sleepData, hydrationData)
-
+const averageSleepQuality = userRepository.dailyUsersQualityAvg(); 
+console.log(averageSleepQuality)
 
 //hydration
 const hydration = new Hydration(user, todayDate);
@@ -108,7 +108,7 @@ let sleepCalendarHoursAverageWeekly = document.querySelector('#sleep-calendar-ho
 let sleepCalendarQualityAverageWeekly = document.querySelector('#sleep-calendar-quality-average-weekly');
 let sleepFriendLongestSleeper = document.querySelector('#sleep-friend-longest-sleeper');
 let sleepFriendsCard = document.querySelector('#sleep-friends-card');
-let sleepFriendWorstSleeper = document.querySelector('#sleep-friend-worst-sleeper');
+const sleepAllUsersQualityAverage = document.querySelector('#sleep-friend-quality-average');
 let sleepInfoCard = document.querySelector('#sleep-info-card');
 let sleepInfoHoursAverageAlltime = document.querySelector('#sleep-info-hours-average-alltime');
 let sleepInfoQualityAverageAlltime = document.querySelector('#sleep-info-quality-average-alltime');
@@ -340,8 +340,9 @@ function displaySleepComparison() {
   const longestSleepers = userRepository.dailyLongestSleepers(todayDate, sleepData);
   longestSleepers.forEach(sleeper => {
     const bestSleeper = userRepository.getUser(sleeper.userID)
-    sleepFriendLongestSleeper.innerText += `${bestSleeper.getFirstName()} `;
+    sleepFriendLongestSleeper.innerHTML += `${bestSleeper.getFirstName()} `;
   });
+  sleepAllUsersQualityAverage.innerText = `${userRepository.dailyUsersQualityAvg()}/5`; 
 }
 
 //Refactor above


### PR DESCRIPTION
## Purpose
_Describe the problem or feature(s) being addressed._
- the average quality of sleep for all user's was not being used or displayed
## Abstract
_How does this change address the problem? Give a brief summary of the change. _
- The sleep card will now show the average sleep quality for all users on the sleep card when the people icon is clicked
#### Pre-Merge TODOs
- [x] fetch the branch, and test on the application, when clicking the people icon, the card should be displaying the longest sleepers and the sleep quality all time for all users
- [x] Check Styling/Syntax
- [x] Check for opportunities for further refactoring

## Learning
_Describe the research stage, any interesting findings or resources to note?_

#### Next Steps
_What needs to be worked on still in this feature/fix?_
- need to display the longest sleepers so that if there are more than one sleeper, the names will display on different lines